### PR TITLE
Fix Apexcharts TypeError issues

### DIFF
--- a/src/components/Charts/ChartOne.tsx
+++ b/src/components/Charts/ChartOne.tsx
@@ -189,6 +189,7 @@ const ChartOne: React.FC = () => {
             series={state.series}
             type="area"
             height={350}
+            width={"100%"}
           />
         </div>
       </div>

--- a/src/components/Charts/ChartTwo.tsx
+++ b/src/components/Charts/ChartTwo.tsx
@@ -143,6 +143,7 @@ const ChartTwo: React.FC = () => {
             series={state.series}
             type="bar"
             height={350}
+            width={"100%"}
           />
         </div>
       </div>


### PR DESCRIPTION
Fix "TypeError: Cannot read property 'ToString' of undefined when bar chart is rendering with data". 

I used [this issue](https://github.com/apexcharts/apexcharts.js/issues/1898) in the ApexCharts repo in order to solve it.

I struggled with this issue for the past few days since I purchased the NextJS flavor of TaliAdmin so I thought it would be helpful to others as well.