### PR TITLE
fix: remove dist folder in import

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 "use client";
-import "jsvectormap/dist/css/jsvectormap.css";
+import "jsvectormap/dist/jsvectormap.css";
 import "flatpickr/dist/flatpickr.min.css";
 import "@/css/satoshi.css";
 import "@/css/style.css";

--- a/src/components/Maps/MapOne.tsx
+++ b/src/components/Maps/MapOne.tsx
@@ -1,6 +1,6 @@
 "use client";
 import jsVectorMap from "jsvectormap";
-import "jsvectormap/dist/css/jsvectormap.css";
+import "jsvectormap/dist/jsvectormap.css";
 import React, { useEffect } from "react";
 import "../../js/us-aea-en";
 


### PR DESCRIPTION
- according to jsvectormap docs, this is no longer required in the latest update

jsvectormap docs:
### BREAKING CHANGES

Removed `js` and `css` from dist folder, so if you're importing jsvectormap from dist/js/jsvectormap.js it becomes dist/jsvectormap.js and css as well.

```html
<!-- 
  /dist/js/jsvectormap.js       -> /dist/jsvectormap.js
  /dist/js/jsvectormap.min.js   -> /dist/jsvectormap.min.js
  /dist/js/jsvectormap.css      -> /dist/jsvectormap.css
  /dist/js/jsvectormap.min.css  -> /dist/jsvectormap.min.css
-->
```