### PR TITLE
fix: nextjs scroll restoration

### DIFF
--- a/src/components/Layouts/DefaultLayout.tsx
+++ b/src/components/Layouts/DefaultLayout.tsx
@@ -12,13 +12,13 @@ export default function DefaultLayout({
   return (
     <>
       {/* <!-- ===== Page Wrapper Start ===== --> */}
-      <div className="flex h-screen overflow-hidden">
+      <div className="flex h-screen">
         {/* <!-- ===== Sidebar Start ===== --> */}
         <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
         {/* <!-- ===== Sidebar End ===== --> */}
 
         {/* <!-- ===== Content Area Start ===== --> */}
-        <div className="relative flex flex-1 flex-col overflow-y-auto overflow-x-hidden">
+        <div className="relative flex flex-1 flex-col lg:ml-72.5">
           {/* <!-- ===== Header Start ===== --> */}
           <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
           {/* <!-- ===== Header End ===== --> */}

--- a/src/components/Layouts/DefaultLayout.tsx
+++ b/src/components/Layouts/DefaultLayout.tsx
@@ -12,7 +12,7 @@ export default function DefaultLayout({
   return (
     <>
       {/* <!-- ===== Page Wrapper Start ===== --> */}
-      <div className="flex h-screen">
+      <div className="flex">
         {/* <!-- ===== Sidebar Start ===== --> */}
         <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
         {/* <!-- ===== Sidebar End ===== --> */}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -329,7 +329,7 @@ const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
   return (
     <ClickOutside onClick={() => setSidebarOpen(false)}>
       <aside
-        className={`absolute left-0 top-0 z-9999 flex h-screen w-72.5 flex-col overflow-y-hidden bg-black duration-300 ease-linear dark:bg-boxdark lg:static lg:translate-x-0 ${
+        className={`fixed left-0 top-0 z-9999 flex h-screen w-72.5 flex-col overflow-y-hidden bg-black duration-300 ease-linear dark:bg-boxdark lg:translate-x-0 ${
           sidebarOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >


### PR DESCRIPTION
The combination of overflow-hidden on the parent container and overflow-y-auto, overflow-x-hidden on the child container affects scroll restoration. 


> Page navigation when clicking list items is for demonstration only and not included in the commit.

## BEFORE

https://github.com/TailAdmin/free-nextjs-admin-dashboard/assets/89559826/0fc9069c-f870-4a79-8394-247dda915738


## AFTER

https://github.com/TailAdmin/free-nextjs-admin-dashboard/assets/89559826/1b86f185-4c73-46af-8492-1de862da4fbc

