### PR TITLE
fix: restore corrupted angle-left and angle-right icons

### DIFF
--- a/src/icons/angle-left.svg
+++ b/src/icons/angle-left.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/icons/angle-right.svg
+++ b/src/icons/angle-right.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M7.5 15L12.5 10L7.5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Fixes #65. Replaced corrupted SVG files with valid icon code.